### PR TITLE
Fixed issue with running when username has spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ docker pull microsoft/azure-cosmosdb-emulator
 To start the image, run the following commands.
 
 ``` 
-md %LOCALAPPDATA%\CosmosDBEmulatorCert 2>nul
-docker run -v %LOCALAPPDATA%\CosmosDBEmulatorCert:c:\CosmosDBEmulator\CosmosDBEmulatorCert -P -t -i microsoft/azure-cosmosdb-emulator
+md "%LOCALAPPDATA%\CosmosDBEmulatorCert" 2>nul
+docker run -v "%LOCALAPPDATA%\CosmosDBEmulatorCert":c:\CosmosDBEmulator\CosmosDBEmulatorCert -P -t -i microsoft/azure-cosmosdb-emulator
 ```
 
 The response looks similar to the following:


### PR DESCRIPTION
The current commands in the readme fail for me since my username (and thus the directory path) had spaces.
Docker would error out with "invalid repository name: must be lowercase" so i had to quote the usage of %LOCALAPPDATA% everywhere when passing it to docker and creating the cert folder.