### PR TITLE
Corrected docker run command volume mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To start the image, run the following commands.
 
 ``` 
 md %LOCALAPPDATA%\CosmosDBEmulatorCert 2>nul
-docker run -v %LOCALAPPDATA%\CosmosDBEmulatorCert:c:\CosmosDBEmulator\CosmosDBEmulatorCert -P -t -i microsoft/azure-cosmosdb-emulator
+docker run -v %LOCALAPPDATA%\CosmosDBEmulatorCert:c:\CosmosDB.Emulator\CosmosDBEmulatorCert -P -t -i microsoft/azure-cosmosdb-emulator
 ```
 
 The response looks similar to the following:


### PR DESCRIPTION
Updated the docker run command to mount the correct volume containing the emulator certificate. Previously the directory containing the emulator certificate was not being mounted, meaning you couldn't get access to the certificate required to connect a client to the emulator.