### PR TITLE
Dockerfile: add MongoDB replica set port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ EXPOSE 10251
 EXPOSE 10252
 EXPOSE 10253
 EXPOSE 10254
+EXPOSE 10255
 
 # Start the interactive shell
 CMD [ "c:\\CosmosDBEmulator\\startemu.cmd" ]


### PR DESCRIPTION
Add the MongoDB replica set port to the list of ports to be exposed.