### PR TITLE
Update dockerfile & avoid need tty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # CosmosDB Emulator Dockerfile
 
 # Indicates that the windowsservercore image will be used as the base image.
-FROM microsoft/windowsservercore
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 # Metadata indicating an image maintainer.
 MAINTAINER mominag@microsoft.com
@@ -21,6 +21,8 @@ RUN powershell.exe -Command $ErrorActionPreference = 'Stop'; \
    Start-Process 'msiexec.exe' -ArgumentList '/i','c:\CosmosDBEmulator\AzureCosmosDB.Emulator.msi','/qn' -Wait
 RUN echo "Installer Done"
 
+RUN md c:\\CosmosDBEmulator\\CosmosDBEmulatorCert
+
 # Expose the required network ports
 EXPOSE 8081
 EXPOSE 8901
@@ -34,6 +36,6 @@ EXPOSE 10255
 EXPOSE 10350
 
 # Start the interactive shell
-CMD [ "c:\\CosmosDBEmulator\\startemu.cmd" ]
+CMD [ "c:\\CosmosDBEmulator\\startemu.cmd"]
 
 

--- a/package_scripts/startemu.cmd
+++ b/package_scripts/startemu.cmd
@@ -15,4 +15,4 @@ echo cd /d ^%%LOCALAPPDATA^%%\CosmosDBEmulatorCert
 echo powershell .\importcert.ps1
 echo --------------------------------------------------------------------------------------------------
 echo Starting interactive shell
-cmd /K
+ping -t localhost > nul


### PR DESCRIPTION
This PR updated the Dockerfile:

* Updating base image
* Ensuring no bind-mount has to be created

Also updates the `startemu.cmd` to a different "never-ending" action that do not need a tty attached (allowing using the emulator in hosts that do not support tty like ACI)