### PR TITLE
Switch to using Server Core 2019 LTSC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # CosmosDB Emulator Dockerfile
 
 # Indicates that the windowsservercore image will be used as the base image.
-FROM microsoft/windowsservercore
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 # Metadata indicating an image maintainer.
 MAINTAINER mominag@microsoft.com


### PR DESCRIPTION
The old microsoft/windowsservercore tag has been deprecated. For this to work it needs to be switched to the new Microsoft Container Repository.